### PR TITLE
Fix Inch CI URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # trot
-[![Build Status](https://travis-ci.org/hexedpackets/trot.svg?branch=master)](https://travis-ci.org/hexedpackets/trot) [![Inline docs](http://inch-ci.org/github/hexedpackets/trot.svg?branch=HEAD)](http://inch-ci.org/github/hexedpackets/trot/branch/HEAD)
+[![Build Status](https://travis-ci.org/hexedpackets/trot.svg?branch=master)](https://travis-ci.org/hexedpackets/trot) [![Inline docs](http://inch-ci.org/github/hexedpackets/trot.svg)](http://inch-ci.org/github/hexedpackets/trot)
 
 Trot is an Elixir web micro-framework based on Plug and Cowboy. The goal of Trot is to make common patterns in Plug easier to use, particularly when writing APIs, without sacrificing flexibility.
 


### PR DESCRIPTION
Hi there,

I had a bug in the last release of InchEx, which caused the evaluated branch to be named `HEAD` (this was never intended).

I fixed it and we now have to update the URLs in your README to point to the original badge and status page, so everything is set up as originally planned. :rocket: 

Sorry for the inconvenience!