### PR TITLE
Add `mix trot.server` mix task

### DIFF
--- a/lib/mix/tasks/trot.server.ex
+++ b/lib/mix/tasks/trot.server.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Trot.Server do
   use Mix.Task
 
+  @shortdoc "Starts application and server"
+
   @moduledoc """
   Starts Trot application with `mix trot.server`
   ## Command line options

--- a/lib/mix/tasks/trot.server.ex
+++ b/lib/mix/tasks/trot.server.ex
@@ -1,6 +1,14 @@
 defmodule Mix.Tasks.Trot.Server do
   use Mix.Task
 
+  @moduledoc """
+  Starts Trot application with `mix trot.server`
+  ## Command line options
+  This task accepts the same command-line arguments as `app.start`. For additional
+  information, refer to the documentation for `Mix.Tasks.App.Start`.
+  For example, to run `trot.server` without checking dependencies:
+    mix trot.server --no-deps-check
+  """
   def run(args) do
     Mix.Task.run "app.start", args
     no_halt

--- a/lib/mix/tasks/trot.server.ex
+++ b/lib/mix/tasks/trot.server.ex
@@ -1,0 +1,12 @@
+defmodule Mix.Tasks.Trot.Server do
+  use Mix.Task
+
+  def run(args) do
+    Mix.Task.run "app.start", args
+    no_halt
+  end
+
+  defp no_halt do
+    :timer.sleep(:infinity)
+  end
+end

--- a/lib/mix/tasks/trot.server.ex
+++ b/lib/mix/tasks/trot.server.ex
@@ -7,6 +7,10 @@ defmodule Mix.Tasks.Trot.Server do
   end
 
   defp no_halt do
-    :timer.sleep(:infinity)
+    unless iex_running?, do: :timer.sleep(:infinity)
+  end
+
+  defp iex_running? do
+    Code.ensure_loaded?(IEx) && IEx.started?
   end
 end


### PR DESCRIPTION
I added `mix trot.server` task for starting application and server.

Becase, I want to deploy trot's app on Heroku. So, I need task for starting application and server. We can't use `iex -S mix ` on production.

```
> mix -h                                                                                                                                                                                                 master [7ecc951] md
mix                   # Run the default task (current: mix run)
mix app.start         # Start all registered apps
mix archive           # List all archives
〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜〜
mix test              # Run a project's tests
mix trot.server       # Starts application and server
iex -S mix            # Start IEx and run the default task
```

What do you think?