### PR TITLE
Add parens to mix.exs function calls

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,15 +7,15 @@ defmodule Trot.Mixfile do
     [app: :trot,
      version: @version,
      elixir: "~> 1.2",
-     deps: deps,
+     deps: deps(),
      name: "Trot",
      docs: [readme: "README.md", main: "README",
             source_ref: "v#{@version}",
             source_url: "https://github.com/hexedpackets/trot"],
 
      # Hex
-     description: description,
-     package: package]
+     description: description(),
+     package: package()]
   end
 
   def application do


### PR DESCRIPTION
Silences (harmless) warnings printed out when trying to use trot with Elixir 1.4.0

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/erik/code/asdf/deps/trot/mix.exs:10

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /Users/erik/code/asdf/deps/trot/mix.exs:17

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/erik/code/asdf/deps/trot/mix.exs:18
```