### PR TITLE
Allow customizing Cowboy protocol_options

### DIFF
--- a/lib/trot/supervisor.ex
+++ b/lib/trot/supervisor.ex
@@ -14,10 +14,11 @@ defmodule Trot.Supervisor do
       port when is_binary(port) -> String.to_integer(port)
       port -> port
     end
+    protocol_options = Application.get_env(:trot, :protocol_options, [])
     router_module = Application.get_env(:trot, :router, Trot.NotFound)
 
     children = [
-      Plug.Adapters.Cowboy.child_spec(:http, router_module, [], [port: port]),
+      Plug.Adapters.Cowboy.child_spec(:http, router_module, [], [port: port, protocol_options: protocol_options]),
     ]
     supervise(children, strategy: :one_for_one)
   end


### PR DESCRIPTION
Hey,

I often see an error like:

```
[error] Cowboy returned 400 because it was unable to parse the request headers.

This may happen because there are no headers, or there are too many headers
or the header name or value are too large (such as a large cookie).

You can customize those values when configuring your http/https
server. The configuration option and default values are shown below:

    protocol_options: [
      max_header_name_length: 64,
      max_header_value_length: 4096,
      max_headers: 100,
      max_request_line_length: 8096
    ]
```

It'll be great if I could override [Plug.Adapters.Cowboy](https://hexdocs.pm/plug/Plug.Adapters.Cowboy.html) `protocol_options` by adding to my `config.ex`:

```ex
config :trot, :protocol_options, [
  max_header_name_length: 1048576,
  max_header_value_length: 1048576,
  max_headers: 10000,
  max_request_line_length: 1048576
]
```

Or alternatively, we could namespace the config options and pass them to Cowboy, for example:

```ex
config :trot, :http, [
  port: 3000,
  timeout: 5000,
  protocol_options: [
    max_header_name_length: 1048576,
    max_header_value_length: 1048576,
    max_headers: 10000,
    max_request_line_length: 1048576
  ]
]
```